### PR TITLE
ストーリー画面に台詞表示

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "bravo-front",
       "version": "0.1.0",
       "dependencies": {
+        "axios": "^1.7.7",
         "next": "14.2.15",
         "react": "^18",
         "react-dom": "^18"
@@ -831,6 +832,11 @@
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
       "dev": true
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -853,6 +859,16 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -988,6 +1004,17 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -1153,6 +1180,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/doctrine": {
@@ -1923,6 +1958,25 @@
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -1946,6 +2000,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fs.realpath": {
@@ -2887,6 +2954,25 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3311,6 +3397,11 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "axios": "^1.7.7",
+    "next": "14.2.15",
     "react": "^18",
-    "react-dom": "^18",
-    "next": "14.2.15"
+    "react-dom": "^18"
   },
   "devDependencies": {
     "eslint": "^8",

--- a/src/app/Develop/page.js
+++ b/src/app/Develop/page.js
@@ -34,11 +34,11 @@ function Develop() {
 
     const deletItem = async ( itemId ) => {
         const res = await fetch('http://127.0.0.1:5000/deletItem', {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ item_id: itemId }),
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ item_id: itemId }),
         });
         const data = await res.json();
         setItems(items.filter(item => item.id !== itemId));

--- a/src/app/Story/page.js
+++ b/src/app/Story/page.js
@@ -60,8 +60,9 @@ function Story() {
         }
     };
 
-    const handleChoice = (choice) => {
+    const handleChoice = async(choice) => {
         console.log("選択肢:", choice.content);
+        console.log("送信するデータ:", JSON.stringify({ choice: choice.id, chapter: chapter }));
         const nextProgress = choice.start;
         setProgress(nextProgress);
 
@@ -72,6 +73,22 @@ function Story() {
 
         // 選択肢の範囲（end）を設定
         setChoiceEnd(choice.end);
+
+        try {
+            const res = await fetch('http://127.0.0.1:5000/story/save', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ choice: choice.id, chapter: chapter }),
+            });
+            if (!res.ok) {
+                throw new Error("Failed to save choice data");
+            }
+            console.log("選択が保存されました");
+        } catch (error) {
+            console.error("選択肢の保存でエラーが発生しました:", error);
+        }
     };
 
     return (

--- a/src/app/Story/page.js
+++ b/src/app/Story/page.js
@@ -1,8 +1,50 @@
-import React from 'react'
+'use client'
+import React, { useState, useEffect } from 'react'
+import axios from 'axios';
 
 function Story() {
+
+    const [progress, setProgress] = useState(0); // ストーリの進み
+    const [display, setDisplay] = useState(''); // 表示する台詞
+    const [people, setPeople] = useState(null); // 喋るキャラクター
+    const [chapterData, setChapterData] = useState(0);
+    
+    useEffect(() => {
+        fetchStory();
+    }, []);
+
+    const fetchStory = async () => {
+        try{
+            const res = await axios.get('http://127.0.0.1:5000/story/3');
+            setChapterData(res.data); // データ全体を保存
+            setProgress(0); // 進捗を最初に戻す
+            if (res.data.length > 0) {
+                setDisplay(res.data[0].sentence); // 最初のセリフを表示
+                setPeople(res.data[0].people); // 最初の話者を設定
+            }
+        } catch(error) {
+            console.error("axiosのエラーが発生しました:", error);
+        }
+        
+    };
+
+    const handleNextSentence = () => {
+        if (progress < chapterData.length - 1) {
+            const nextProgress = progress + 1;
+            setProgress(nextProgress);
+            setDisplay(chapterData[nextProgress].sentence);
+            setPeople(chapterData[nextProgress].people);
+        } else {
+            console.log("最後のセリフです"); // 最後のセリフに達したらメッセージを表示
+        }
+    };
+
     return (
-        <div>Story</div>
+        <div>
+            <h1>Story</h1>
+            <p><strong>話者 {people}:</strong> {display}</p>
+            <button onClick={handleNextSentence}>次へ</button>
+        </div>
     )
 }
 

--- a/src/app/Story/page.js
+++ b/src/app/Story/page.js
@@ -4,48 +4,94 @@ import axios from 'axios';
 
 function Story() {
 
-    const [progress, setProgress] = useState(0); // ストーリの進み
+    const [progress, setProgress] = useState(0); // ストーリーの進行
     const [display, setDisplay] = useState(''); // 表示する台詞
-    const [people, setPeople] = useState(null); // 喋るキャラクター
-    const [chapterData, setChapterData] = useState(0);
-    
+    const [people, setPeople] = useState(null); // 話者のキャラクター
+    const [chapter, setChapter] = useState(1); // 現在の章
+    const [chapterData, setChapterData] = useState(null); // 章のデータ
+    const [choices, setChoices] = useState([]); // 選択肢のデータ
+    const [choiceEnd, setChoiceEnd] = useState(null); // 選択肢の終わりのインデックス
+
     useEffect(() => {
         fetchStory();
     }, []);
 
     const fetchStory = async () => {
-        try{
+        try {
             const res = await axios.get('http://127.0.0.1:5000/story/3');
             setChapterData(res.data); // データ全体を保存
-            setProgress(0); // 進捗を最初に戻す
+            setProgress(0); // 進捗をリセット
+            setChoiceEnd(null); // 選択肢の範囲をリセット
             if (res.data.length > 0) {
                 setDisplay(res.data[0].sentence); // 最初のセリフを表示
                 setPeople(res.data[0].people); // 最初の話者を設定
             }
-        } catch(error) {
+        } catch (error) {
             console.error("axiosのエラーが発生しました:", error);
         }
-        
     };
 
     const handleNextSentence = () => {
-        if (progress < chapterData.length - 1) {
+        // 範囲外であれば進行しない
+        if (chapterData && progress < chapterData.length - 1) {
             const nextProgress = progress + 1;
+
+            // 選択肢範囲の終わりに達した場合、進行を止める
+            if (choiceEnd !== null && nextProgress > choiceEnd) {
+                console.log("選択肢の終わりに達しました");
+                return;
+            }
+
             setProgress(nextProgress);
-            setDisplay(chapterData[nextProgress].sentence);
-            setPeople(chapterData[nextProgress].people);
-        } else {
+            const nextSentence = chapterData[nextProgress];
+
+            if (nextSentence.state && Array.isArray(nextSentence.sentence)) {
+                setChoices(nextSentence.sentence); // 選択肢を設定
+                setDisplay(''); // セリフの表示を空にする
+            } else {
+                setDisplay(nextSentence.sentence); // 通常のセリフを表示
+                setChoices([]); // 選択肢をクリア
+            }
+
+            setPeople(nextSentence.people); // 話者を更新
+        } else if (chapterData) {
             console.log("最後のセリフです"); // 最後のセリフに達したらメッセージを表示
+            setChapter(chapter + 1);
         }
+    };
+
+    const handleChoice = (choice) => {
+        console.log("選択肢:", choice.content);
+        const nextProgress = choice.start;
+        setProgress(nextProgress);
+
+        const nextSentence = chapterData[nextProgress];
+        setDisplay(nextSentence.sentence); // 選択肢に基づいたセリフを表示
+        setPeople(nextSentence.people); // 話者を設定
+        setChoices([]); // 選択肢をクリア
+
+        // 選択肢の範囲（end）を設定
+        setChoiceEnd(choice.end);
     };
 
     return (
         <div>
             <h1>Story</h1>
             <p><strong>話者 {people}:</strong> {display}</p>
-            <button onClick={handleNextSentence}>次へ</button>
+            {choices.length === 0 ? (
+                <button onClick={handleNextSentence}>次へ</button>
+            ) : (
+                <div>
+                    <h2>選択肢</h2>
+                    {choices.map((choice) => (
+                        <button key={choice.id} onClick={() => handleChoice(choice)}>
+                            {choice.content}
+                        </button>
+                    ))}
+                </div>
+            )}
         </div>
-    )
+    );
 }
 
-export default Story
+export default Story;

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -14,6 +14,7 @@ export default function RootLayout({ children }) {
           <Link href={"/"}>/Home</Link>
           <Link href={"/Start"}>/Start</Link>
           <Link href={"/Develop"}>/Develop</Link>
+          <Link href={"/Story"}>/Story</Link>
         </div>
 
         <div>{children}</div>


### PR DESCRIPTION
## やったこと
- ストーリー画面で台詞を順に表示
- 選択肢によって指定された範囲の台詞のみ表示
- 選択肢の保存

## 変更点
- ストーリー画面作成
- 台詞がクリックするごとに更新するようにした
- 選択肢によって表示する台詞が変わるようにした
- 選択したら選択肢のidとその章をバックエンドに送信

## 動作確認
スクショや動画で動作確認をした画面を貼り付け
![Uploading スクリーンショット 2024-11-04 1.14.35.png…]()


## まだやってないこと
- キャラクターの名前表示
- CSSあててない

## 伝えときたいこと
- 

## 関連Issue
- Issue: #4 
